### PR TITLE
wb_acq_core: update INT_TRIG_SEL description.

### DIFF
--- a/modules/wishbone/wb_acq_core/wbgen/acq_core.wb
+++ b/modules/wishbone/wb_acq_core/wbgen/acq_core.wb
@@ -212,8 +212,8 @@ peripheral {
     };
 
     field {
-      name = "Channel selection for internal trigger";
-      description = "00: channel 1\n01: channel 2\n10: channel 3\nn: channel n+1";
+      name = "Atom selection for internal trigger (atom within the channel selected by DTRIG_WHICH)";
+      description = "00: atom 1\n01: atom 2\n10: atom 3\nn: atom n+1";
       prefix = "int_trig_sel";
       type = SLV;
       size = 5;


### PR DESCRIPTION
This file uses "channel" to refer to acquisition channels. So for atoms
in each channel, we should use "atom" or some other word, to avoid
confusion.