### PR TITLE
Replace the FMC250/130 I2C Si57x master interface with xwb_si57x_ctrl

### DIFF
--- a/modules/wishbone/ifc_wishbone_pkg.vhd
+++ b/modules/wishbone/ifc_wishbone_pkg.vhd
@@ -2201,6 +2201,9 @@ package ifc_wishbone_pkg is
   component wb_fmc_active_clk
   generic
   (
+    g_si57x_i2c_addr                          : std_logic_vector(6 downto 0);
+    g_si57x_7ppm_variant                      : boolean;
+    g_si57x_i2c_clk_div                       : natural range 1 to 65536;
     g_interface_mode                          : t_wishbone_interface_mode      := CLASSIC;
     g_address_granularity                     : t_wishbone_address_granularity := WORD;
     g_with_extra_wb_reg                       : boolean := false
@@ -2267,6 +2270,9 @@ package ifc_wishbone_pkg is
   component xwb_fmc_active_clk
   generic
   (
+    g_si57x_i2c_addr                          : std_logic_vector(6 downto 0);
+    g_si57x_7ppm_variant                      : boolean;
+    g_si57x_i2c_clk_div                       : natural range 1 to 65536;
     g_interface_mode                          : t_wishbone_interface_mode      := CLASSIC;
     g_address_granularity                     : t_wishbone_address_granularity := WORD;
     g_with_extra_wb_reg                       : boolean := false

--- a/modules/wishbone/wb_fmc130m_4ch/wb_fmc130m_4ch.vhd
+++ b/modules/wishbone/wb_fmc130m_4ch/wb_fmc130m_4ch.vhd
@@ -1169,6 +1169,13 @@ begin
   -- FMC Active Clock is slave number 2, word addressed
   cmp_fmc_active_clk : xwb_fmc_active_clk
   generic map(
+    -- I2C address for Si571AJC000337DG
+    g_si57x_i2c_addr                        => "1001001",
+    g_si57x_7ppm_variant                    => false,
+    -- Considering a 125 MHz clock, this should result in a 250 kHz SCL
+    -- frequency, but the measured SCL frequency is 180 kHz, this seems to be a
+    -- bug in i2c_master_byte_ctrl or i2c_master_bit_ctrl.
+    g_si57x_i2c_clk_div                     => 125,
     g_interface_mode                        => g_interface_mode,
     g_address_granularity                   => g_address_granularity,
     g_with_extra_wb_reg                     => g_with_extra_wb_reg

--- a/modules/wishbone/wb_fmc250m_4ch/wb_fmc250m_4ch.vhd
+++ b/modules/wishbone/wb_fmc250m_4ch/wb_fmc250m_4ch.vhd
@@ -1235,6 +1235,13 @@ begin
 
   cmp_fmc_active_clk : xwb_fmc_active_clk
   generic map(
+    -- I2C address for Si571AJC000337DG
+    g_si57x_i2c_addr                        => "1001001",
+    g_si57x_7ppm_variant                    => false,
+    -- Considering a 125 MHz clock, this should result in a 250 kHz SCL
+    -- frequency, but the measured SCL frequency is 180 kHz, this seems to be a
+    -- bug in i2c_master_byte_ctrl or i2c_master_bit_ctrl.
+    g_si57x_i2c_clk_div                     => 125,
     g_interface_mode                        => g_interface_mode,
     g_address_granularity                   => g_address_granularity,
     g_with_extra_wb_reg                     => g_with_extra_wb_reg

--- a/modules/wishbone/wb_fmc_active_clk/xwb_fmc_active_clk.vhd
+++ b/modules/wishbone/wb_fmc_active_clk/xwb_fmc_active_clk.vhd
@@ -29,6 +29,9 @@ use work.ifc_wishbone_pkg.all;
 entity xwb_fmc_active_clk is
 generic
 (
+  g_si57x_i2c_addr                          : std_logic_vector(6 downto 0);
+  g_si57x_7ppm_variant                      : boolean;
+  g_si57x_i2c_clk_div                       : natural range 1 to 65536;
   g_interface_mode                          : t_wishbone_interface_mode      := CLASSIC;
   g_address_granularity                     : t_wishbone_address_granularity := WORD;
   g_with_extra_wb_reg                       : boolean := false
@@ -89,6 +92,9 @@ begin
 
   cmp_wb_fmc_active_clk : wb_fmc_active_clk
   generic map (
+    g_si57x_i2c_addr                         => g_si57x_i2c_addr,
+    g_si57x_7ppm_variant                     => g_si57x_7ppm_variant,
+    g_si57x_i2c_clk_div                      => g_si57x_i2c_clk_div,
     g_interface_mode                         => g_interface_mode,
     g_address_granularity                    => g_address_granularity,
     g_with_extra_wb_reg                      => g_with_extra_wb_reg


### PR DESCRIPTION
The xwb_si57x_ctrl core provides an higher level interface for Si57x programmable oscillators, the software side doesn't need to control a RAW I2C interface anymore.